### PR TITLE
Allow retries when npm registry fails with ENOAUDIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ To set a custom threshold:
 ```
 npx @lennym/ciaudit --level moderate
 ```
+
+To retry when audit fails with `ENOAUDIT` (frequently the result of issues with npm infrastructure):
+
+```
+npx @lennym/ciaudit --retries 3
+```
+


### PR DESCRIPTION
The npm endpoint for audit seems to be frequently problematic and often fails with ENOAUDIT error. Allow a configurable number of retries to brute-force the endpoint.